### PR TITLE
Fix to set variables for non-interactive shells

### DIFF
--- a/system/bash_profile.symlink
+++ b/system/bash_profile.symlink
@@ -3,7 +3,7 @@
 
 # Get the good stuff...
 # if running bash
-if [[ -n "$BASH_VERSION" ]] ; then
+if [[ -n "$BASH_VERSION" ]] || [[ "$0" == *bash ]] ; then
     # include .bashrc if it exists
     if [[ -f "$HOME/.bashrc" ]] ; then
 	. "$HOME/.bashrc"

--- a/system/bashrc.symlink
+++ b/system/bashrc.symlink
@@ -22,6 +22,10 @@ function _source_if_exists {
 #     $- = hBc
 #
 
+
+# User-specific vars and paths (needed for both interactive and non-interactive shells
+_source_if_exists "${HOME}/.vars" "${HOME}/.path" ;
+
 case $- in *i* )
 
     # Source global definitions
@@ -36,8 +40,8 @@ case $- in *i* )
     # Set the PS1 prompt for interactive shells
     _source_if_exists "${HOME}/.prompt" ;
 
-    # User-specific aliases, functions, vars and paths
-    _source_if_exists "${HOME}/.aliases" "${HOME}/.functions" "${HOME}/.vars" "${HOME}/.path" ;
+    # User-specific aliases and functions
+    _source_if_exists "${HOME}/.aliases" "${HOME}/.functions";
 
     # After everything else
     _source_if_exists "${HOME}/.after_dotfiles" ;


### PR DESCRIPTION
Fix for issue at https://github.com/ThePrez/ServiceCommander-IBMi/issues/35

In a nutshell, bash is not properly detected when invoked from QP2SHELL (and likely others) unless `-i` is specified. 