### PR TITLE
Only show banner if interactive shell

### DIFF
--- a/system/bash_profile.symlink
+++ b/system/bash_profile.symlink
@@ -11,10 +11,12 @@ if [[ -n "$BASH_VERSION" ]] || [[ "$0" == *bash ]] ; then
 fi
 
 
-# Print a shell banner for login shells
-echo ; bash --version ; echo ;
+if [[ "$-" == *i* ]]; then
+    # Print a shell banner for login shells
+    echo ; bash --version ; echo ;
 
-# Print .dotfiles version
-[[ -f "${HOME}/.dotfiles/VERSION" ]] \
-&& echo "This shell has been enhanced by ibmi-dotfiles version $(cat $HOME/.dotfiles/VERSION)" \
-&& echo
+    # Print .dotfiles version
+    [[ -f "${HOME}/.dotfiles/VERSION" ]] \
+    && echo "This shell has been enhanced by ibmi-dotfiles version $(cat $HOME/.dotfiles/VERSION)" \
+    && echo
+fi


### PR DESCRIPTION
If a non-interactive shell, there's no need for the banner, and it may interfere with other processing